### PR TITLE
Update to scraml-sbt-plugin 0.4.12 and latest scala.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "scraml-test-scala"
 
 organization := "io.atomicbits"
 
-version := "0.4.9-SNAPSHOT"
+version := "0.4.12-SNAPSHOT"
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.11.8"
 
 // Sonatype snapshot resolver is needed to fetch SNAPSHOT releases of scraml
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("io.atomicbits"      % "scraml-sbt-plugin"   % "0.4.9-SNAPSHOT")
+addSbtPlugin("io.atomicbits"      % "scraml-sbt-plugin"   % "0.4.12")
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
## Dependency resolution errors
Current develop branch (the github default) fails to resolve a transitive dependency of scraml-sbt-plugin 0.4.9-SNAPSHOT.

`
[error] (*:update) sbt.ResolveException: unresolved dependency: io.atomicbits#scraml-generator_2.10;0.4.9-SNAPSHOT: not found
`

## Update to latest working version
I've bumped scraml-sbt-plugin to 0.4.12 as that's the latest version I could get this to compile against. That should get this example back on its feet.

## Problems with scraml-sbt-plugin 0.4.13 and 0.4.14
Looks like later versions of scraml-sbt-plugin fail to add `io.atomicbits:scraml-dsl-scala` to the libraryDependencies. I'm still getting my bearings with raml/scraml, so I don't know if that's a bug or intentional.

scraml-sbt-plugin 0.4.12:
```
> export libraryDependencies
List(io.atomicbits:scraml-dsl-scala:0.4.12, org.scala-lang:scala-library:2.11.8, com.ning:async-http-client:1.9.31, ch.qos.logback:logback-classic:1.1.1:test, org.scalatest:scalatest:2.2.1:test, org.scalacheck:scalacheck:1.12.1:test, com.github.tomakehurst:wiremock:1.56:test)
```

scraml-sbt-plugin 0.4.13:
```
> export libraryDependencies
List(org.scala-lang:scala-library:2.11.8, com.ning:async-http-client:1.9.31, ch.qos.logback:logback-classic:1.1.1:test, org.scalatest:scalatest:2.2.1:test, org.scalacheck:scalacheck:1.12.1:test, com.github.tomakehurst:wiremock:1.56:test)
```
